### PR TITLE
fix renamed no fail property on gameplay modifiers

### DIFF
--- a/BeatSaberCustomCampaigns/CustomGameplayModifiers.cs
+++ b/BeatSaberCustomCampaigns/CustomGameplayModifiers.cs
@@ -11,7 +11,7 @@ namespace BeatSaberCustomCampaigns
         public ChallengeModifiers challengeModifiers;
 
         public CustomGameplayModifiers(GameplayModifiers gameplayModifiers) :
-                base(gameplayModifiers.demoNoFail, gameplayModifiers.demoNoObstacles, gameplayModifiers.energyType, gameplayModifiers.noFail, gameplayModifiers.instaFail,
+                base(gameplayModifiers.demoNoFail, gameplayModifiers.demoNoObstacles, gameplayModifiers.energyType, gameplayModifiers.noFailOn0Energy, gameplayModifiers.instaFail,
                      gameplayModifiers.failOnSaberClash, gameplayModifiers.enabledObstacleType, gameplayModifiers.noBombs, gameplayModifiers.fastNotes,
                      gameplayModifiers.strictAngles, gameplayModifiers.disappearingArrows, gameplayModifiers.songSpeed, gameplayModifiers.noArrows, gameplayModifiers.ghostNotes)
         {


### PR DESCRIPTION
This patch gets the mod to work again for ```1.13.2```.